### PR TITLE
Fix fair_die sometimes returning n

### DIFF
--- a/vose/sampler.pyx
+++ b/vose/sampler.pyx
@@ -24,7 +24,7 @@ cdef int fair_die(int n):
         n: The number of faces on the die.
 
     """
-    return int((<double>rand() / RAND_MAX) * n)
+    return int((<double>rand() / (RAND_MAX + 1.0)) * n)
 
 
 cdef bint coin_toss(float p):


### PR DESCRIPTION
fair_die(n) is supposed to generate a random number between 0 and n excluded, but sometimes it returned n.
This causes sample_1 to access the proba and alias arrays with an invalid index, resulting in an undefined behavior.
This pull requests fixes the issue by dividing rand() by RAND_MAX + 1 to get a value between 0 (included) and 1 (excluded) before multiplying by n.