### PR TITLE
Handle non-normalized weights

### DIFF
--- a/vose/sampler.pyx
+++ b/vose/sampler.pyx
@@ -68,7 +68,7 @@ cdef class Sampler:
         cdef np.float_t [:] proba = np.zeros(n, dtype=float)
 
         # Compute the average probability and cache it for later use.
-        cdef np.float_t avg = 1. / n
+        cdef np.float_t avg = np.sum(weights) / n
 
         # Create two stacks to act as worklists as we populate the tables.
         cdef deque[int] small = deque[int]()
@@ -98,7 +98,7 @@ cdef class Sampler:
 
             # These probabilities have not yet been scaled up to be such that 1 / n is given weight
             # 1.0. We do this here instead.
-            proba[less] = weights[less] * n
+            proba[less] = weights[less] / avg
             alias[less] = more
 
             # Decrease the probability of the larger one by the appropriate amount.


### PR DESCRIPTION
The documentation currently states:

> You first have to initialize a sampler with an array of weights. **These weights are not required to sum up to 1.**

But if you pass weights that don't sum to 1 the results are not correct. For example:

```pycon
>>> weights = np.arange(1, 6, dtype=float)
>>> sampler = vose.Sampler(weights=weights)
>>> k = 100_000
>>> np.bincount(sampler.sample(k=k)) / k * weights.sum()
array([2.9775 , 3.03495, 2.9991 , 2.99355, 2.9949 ])
```

The proposed change fixes this at the cost of calculating the sum of the weights during construction, which I assume is fine since construction is *O(n)* anyway. Now the output is as expected:

```pycon
array([1.0245, 1.9872, 2.9973, 3.999 , 4.992 ])
```