### PR TITLE
Enable reproducibility using instance-bound RNG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can set the `k` parameter in order to produce multiple samples.
 
 ```py
 >>> sampler.sample(k=10)
-array([1, 1, 2, 1, 2, 1, 0, 1, 3, 3])
+array([1, 2, 1, 1, 1, 2, 1, 3, 1, 0])
 
 ```
 
@@ -95,7 +95,7 @@ It seems to be working correctly; at least according to the following [chi-squar
 >>> import numpy as np
 >>> from scipy import stats
 
->>> rng = np.random.RandomState(42)
+>>> rng = np.random.default_rng(seed=42)
 >>> k = 1000
 
 >>> for n in range(3, 20):
@@ -104,6 +104,19 @@ It seems to be working correctly; at least according to the following [chi-squar
 ...     samples = sampler.sample(k)
 ...     chi2 = stats.chisquare(f_obs=np.bincount(samples), f_exp=weights * k)
 ...     assert chi2.pvalue > .05
+
+```
+
+It is also reproducible:
+
+```py
+>>> import numpy as np
+>>> import vose
+>>> probs = np.array([0.5, 0.5])
+>>> a = vose.Sampler(probs, seed=0)
+>>> b = vose.Sampler(probs, seed=0)
+>>> for _ in range(10000):
+...     assert a.sample() == b.sample()
 
 ```
 

--- a/vose/sampler.pxd
+++ b/vose/sampler.pxd
@@ -1,10 +1,17 @@
 cimport numpy as np
 
+from libcpp.random cimport mt19937
+from libcpp.random cimport uniform_real_distribution
+from libcpp.random cimport uniform_int_distribution
+
 cdef class Sampler:
 
     cdef int n
     cdef np.int64_t [:] alias
     cdef np.float_t [:] proba
+    cdef mt19937 rng
+    cdef uniform_int_distribution[int] fair_die
+    cdef uniform_real_distribution[double] coin_toss
 
     cdef int sample_1(self)
     cdef np.int64_t [:] sample_k(self, int k)


### PR DESCRIPTION
Alternative implementation to #3 which fixes #2. I ran the benchmark before and after the change and didn't see any difference.