### PR TITLE
Switch to 64-bit RNG and allow reseeding of RNG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can then call the `.sample()` method to sample a random integer in range `[0
 
 ```py
 >>> sampler.sample()
-2
+3
 
 ```
 
@@ -35,7 +35,7 @@ You can set the `k` parameter in order to produce multiple samples.
 
 ```py
 >>> sampler.sample(k=10)
-array([1, 2, 1, 1, 1, 2, 1, 3, 1, 0])
+array([3, 3, 2, 1, 1, 2, 2, 3, 0, 2])
 
 ```
 
@@ -117,6 +117,21 @@ It is also reproducible:
 >>> b = vose.Sampler(probs, seed=0)
 >>> for _ in range(10000):
 ...     assert a.sample() == b.sample()
+
+```
+
+Note that the `seed` method can be used to set the state of the sampler's RNG without having to re-initialize the weights:
+
+```py
+>>> import numpy as np
+>>> import vose
+>>> probs = np.ones(5)
+>>> a = vose.Sampler(probs, seed=3)
+>>> a.sample(4)
+array([2, 2, 2, 3])
+>>> a.seed(3)
+>>> a.sample(4)
+array([2, 2, 2, 3])
 
 ```
 

--- a/vose/sampler.pxd
+++ b/vose/sampler.pxd
@@ -1,6 +1,6 @@
 cimport numpy as np
 
-from libcpp.random cimport mt19937
+from libcpp.random cimport mt19937_64
 from libcpp.random cimport uniform_real_distribution
 from libcpp.random cimport uniform_int_distribution
 
@@ -9,7 +9,7 @@ cdef class Sampler:
     cdef int n
     cdef np.int64_t [:] alias
     cdef np.float_t [:] proba
-    cdef mt19937 rng
+    cdef mt19937_64 rng
     cdef uniform_int_distribution[int] fair_die
     cdef uniform_real_distribution[double] coin_toss
 


### PR DESCRIPTION
Two small proposed changes:

* The current RNG is 32-bit. I've observed strange behavior--the distribution seems to change--when it is seeded using 64-bit numbers (which happens in our codebase). Switching to a 64-bit RNG fixes these issues and also allows people to sample from very large multinomials.
* Our codebase requires a deterministic mapping from integers to random samples from a multinomial. One easy way of doing this is to allow the sampler's RNG to be seeded outside of the constructor, so I'd like to expose this method.